### PR TITLE
🩹 Fix chat ID check condition in MessageCollectorHandler

### DIFF
--- a/internal/handlers/publichandlers/message_collector.go
+++ b/internal/handlers/publichandlers/message_collector.go
@@ -57,7 +57,7 @@ func (h *MessageCollectorHandler) CheckUpdate(b *gotgbot.Bot, ctx *ext.Context) 
 
 	formattedSuperGroupChatId := utils.ChatIdToFullChatId(h.config.SuperGroupChatID)
 	// Check if the chat is in the monitored list and from the supergroup
-	return msg.SenderChat != nil && msg.SenderChat.Id == formattedSuperGroupChatId &&
+	return msg.Chat.Id == formattedSuperGroupChatId &&
 		(h.config.IsMonitoredTopic(int(msg.MessageThreadId)) ||
 			(h.config.IsMonitoredTopic(0) && !msg.IsTopicMessage)) // small hack for root topic 0 (1 in links)
 }


### PR DESCRIPTION
The condition for verifying if a chat is from the monitored supergroup has been corrected. Instead of checking the `SenderChat` ID, we now ensure that the `Chat.ID` aligns with the formatted supergroup chat ID. This adjustment enhances the accuracy of supergroup chat identification, particularly when handling monitored topics or the root topic. This fix resolves potential issues where messages might have been inaccurately processed due to incorrect chat ID verification, ensuring reliable operation within the message collection functionality.