### PR TITLE
🚸 Enhance user feedback for private chat command restriction

### DIFF
--- a/internal/utils/handler_helpers.go
+++ b/internal/utils/handler_helpers.go
@@ -33,7 +33,9 @@ func CheckPrivateChatType(b *gotgbot.Bot, ctx *ext.Context) bool {
 	msg := ctx.EffectiveMessage
 
 	if msg.Chat.Type != constants.PrivateChatType {
-		if _, err := ReplyAndDeleteWithReplayAfterDelay(b, msg, "Команда доступна только в личном чате.\nВведенная вами команда и это сообщение автоматически удалятся через 10 секунд.", 10, nil); err != nil {
+		if _, err := ReplyAndDeleteWithReplayAfterDelay(b, msg, "*Прошу прощения* 🧐\n\nЭта команда работает только в _личной беседе_ со мной. Напишите мне напрямую, и я с удовольствием помогу.\n\nДанное сообщение и твоя команда будут автоматически удалены через 10 секунд.", 10, &gotgbot.SendMessageOpts{
+			ParseMode: "Markdown",
+		}); err != nil {
 			log.Printf("Failed to send private-only message: %v", err)
 		}
 		return false


### PR DESCRIPTION
Updated the message feedback when a user attempts to use a bot command outside a private chat. The new response provides a more engaging and clearer explanation in Markdown format, informing the user that the command is only available in a direct conversation with the bot. Additionally, the explanation includes a friendly apology and reassurance that the message and user's command will be automatically deleted in 10 seconds. The change aims to improve user experience by making the interaction more courteous and the instructions clearer.