### PR TITLE
📌 Add bot permission documentation and implement message pinning capa…

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ A Telegram bot for Evocoders Club management implemented in Go. Helps moderate d
 
 For more details on bot usage, use the `/help` command in the bot chat.
 
+## 🔑 Required Bot Permissions
+
+For the bot to function properly, it must have the following admin permissions in the Telegram supergroup:
+
+- 📌 **Pin messages**: Required for pinning event announcements and important information
+- 🗑️ **Delete messages**: Required for clearing service messages and moderating threads
+
+To assign these permissions, add the bot as an administrator in your group and enable these specific rights.
+
 ## 💾 Database
 
 The bot uses PostgreSQL with automatically initialized tables:

--- a/internal/handlers/adminhandlers/eventhandlers/event_start_handler.go
+++ b/internal/handlers/adminhandlers/eventhandlers/event_start_handler.go
@@ -300,11 +300,19 @@ func (h *eventStartHandler) handleCallbackYes(b *gotgbot.Bot, ctx *ext.Context) 
 	}
 
 	// Send announcement message with the event link to the announcement topic if configured
-	announcementMsg := fmt.Sprintf("🔴 *НАЧЕИНАЕМ ИВЕНТ!* 🔴\n\n📅 *%s*\n\nИспользуй кнопку ниже, чтобы присоединиться ⬇️", event.Name)
-	h.messageSenderService.SendMarkdown(utils.ChatIdToFullChatId(h.config.SuperGroupChatID), announcementMsg, &gotgbot.SendMessageOpts{
+	announcementMsg := fmt.Sprintf("🔴 *НАЧИНАЕМ ИВЕНТ!* 🔴\n\n📅 *%s*\n\nИспользуй кнопку ниже, чтобы присоединиться ⬇️", event.Name)
+	sentAnnouncementMsg, err := h.messageSenderService.SendMarkdownWithReturnMessage(utils.ChatIdToFullChatId(h.config.SuperGroupChatID), announcementMsg, &gotgbot.SendMessageOpts{
 		MessageThreadId: int64(h.config.AnnouncementTopicID),
 		ReplyMarkup:     buttonWithLink,
 	})
+
+	// Pin the announcement message with notification for all users
+	if err == nil && sentAnnouncementMsg != nil {
+		err = h.messageSenderService.PinMessageWithNotification(sentAnnouncementMsg.Chat.Id, sentAnnouncementMsg.MessageId, false)
+		if err != nil {
+			log.Printf("%s: Error pinning announcement message: %v", utils.GetCurrentTypeName(), err)
+		}
+	}
 
 	// Confirmation message
 	h.messageSenderService.ReplyMarkdown(

--- a/internal/services/message_sender_service.go
+++ b/internal/services/message_sender_service.go
@@ -77,6 +77,35 @@ func (s *MessageSenderService) SendMarkdown(chatId int64, text string, opts *got
 	return err
 }
 
+// Send markdown message to chat and return the sent message
+func (s *MessageSenderService) SendMarkdownWithReturnMessage(chatId int64, text string, opts *gotgbot.SendMessageOpts) (*gotgbot.Message, error) {
+	// default options for markdown messages
+	if opts == nil {
+		opts = &gotgbot.SendMessageOpts{
+			ParseMode: "Markdown",
+			LinkPreviewOptions: &gotgbot.LinkPreviewOptions{
+				IsDisabled: true,
+			},
+		}
+	} else {
+		opts.ParseMode = "Markdown"
+		// default link preview options are disabled
+		if opts.LinkPreviewOptions == nil {
+			opts.LinkPreviewOptions = &gotgbot.LinkPreviewOptions{
+				IsDisabled: true,
+			}
+		}
+	}
+
+	sentMsg, err := s.bot.SendMessage(chatId, text, opts)
+
+	if err != nil {
+		log.Printf("%s: SendMarkdownWithReturnMessage: Failed to send message: %v", utils.GetCurrentTypeName(), err)
+	}
+
+	return sentMsg, err
+}
+
 // Send html message to chat
 func (s *MessageSenderService) SendHtml(chatId int64, text string, opts *gotgbot.SendMessageOpts) error {
 	// default options for html messages
@@ -427,6 +456,19 @@ func (s *MessageSenderService) RemoveInlineKeyboard(chatID int64, messageID int6
 
 	if err != nil {
 		log.Printf("%s: Error removing inline keyboard: %v", utils.GetCurrentTypeName(), err)
+	}
+
+	return err
+}
+
+// PinMessageWithNotification pins a message with optional notification to all users
+func (s *MessageSenderService) PinMessageWithNotification(chatID int64, messageID int64, disableNotification bool) error {
+	_, err := s.bot.PinChatMessage(chatID, messageID, &gotgbot.PinChatMessageOpts{
+		DisableNotification: disableNotification,
+	})
+
+	if err != nil {
+		log.Printf("%s: Error pinning message: %v", utils.GetCurrentTypeName(), err)
 	}
 
 	return err


### PR DESCRIPTION
…bilities

- Updated README.md to include a new section, "Required Bot Permissions," which outlines the permissions necessary for bot functionalities such as pinning messages and deleting service messages.
- Enhanced the event start handler to pin announcement messages with notifications to the Telegram supergroup when starting an event.
- Implemented a new function, `SendMarkdownWithReturnMessage`, in the MessageSenderService to send a markdown message and return the sent message object for further operations.
- Added `PinMessageWithNotification` method in the MessageSenderService to pin messages with an option to disable notifications.