### PR TITLE
♻️ Refactor chat ID conversion in summarization service

### DIFF
--- a/internal/services/summarization_service.go
+++ b/internal/services/summarization_service.go
@@ -171,7 +171,7 @@ func (s *SummarizationService) summarizeTopicMessages(ctx context.Context, topic
 	finalSummary := fmt.Sprintf("%s\n\n%s", title, summary)
 
 	// Determine the target chat ID and options with summary topic ID
-	var targetChatID int64 = int64(s.config.SuperGroupChatID)
+	var targetChatID int64 = utils.ChatIdToFullChatId(int64(s.config.SuperGroupChatID))
 	var opts *gotgbot.SendMessageOpts = &gotgbot.SendMessageOpts{
 		MessageThreadId: int64(s.config.SummaryTopicID),
 	}


### PR DESCRIPTION
Updated the target chat ID determination process within the summarization service by converting the supergroup chat ID to a full chat ID format using the `utils.ChatIdToFullChatId` method. This modification ensures the correct chat ID format is used for message sending operations, enhancing compatibility and functionality when interacting with chat services. The change improves message routing by explicitly handling chat ID conversions, aligning with expected formats in the message sending options.