### PR TITLE
🥅 Implement rate limiting handling and delay in summarization service

### DIFF
--- a/internal/utils/string_utils.go
+++ b/internal/utils/string_utils.go
@@ -1,0 +1,22 @@
+package utils
+
+import (
+	"regexp"
+	"strings"
+)
+
+// IndexAny finds the first index of the specified substring in a string
+func IndexAny(s, substr string) int {
+	return strings.Index(s, substr)
+}
+
+// ExtractNumber extracts the first number from a string
+// Example: from "FLOOD_WAIT (8)" it extracts "8"
+func ExtractNumber(s string) string {
+	re := regexp.MustCompile(`\((\d+)\)`)
+	matches := re.FindStringSubmatch(s)
+	if len(matches) > 1 {
+		return matches[1]
+	}
+	return ""
+}


### PR DESCRIPTION
Added functionality to the daily summarization process to handle rate limiting by introducing a delay between processing monitored topics. This helps to avoid hitting rate limits during operations. Additionally, a retry logic with exponential backoff was added to the message retrieval function, including a specific case for handling FLOOD_WAIT errors by extracting the wait time and adjusting processing accordingly. Introduced a new utility file, `string_utils.go`, providing helper functions to assist in parsing and extracting numeric information from error messages.