### PR TITLE
♻️ Refactor code to rename InviteTopicID to IntroTopicID

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,7 +22,7 @@ type Config struct {
 	ToolTopicID         int
 	ContentTopicID      int
 	AnnouncementTopicID int
-	InviteTopicID       int
+	IntroTopicID        int
 
 	// Telegram User Client
 	TGUserClientAppID       int
@@ -123,13 +123,13 @@ func LoadConfig() (*Config, error) {
 		config.AnnouncementTopicID = announcementTopicID
 	}
 
-	inviteTopicIDStr := os.Getenv("TG_EVO_BOT_INVITE_TOPIC_ID")
-	if inviteTopicIDStr != "" {
-		inviteTopicID, err := strconv.Atoi(inviteTopicIDStr)
+	introTopicIDStr := os.Getenv("TG_EVO_BOT_INTRO_TOPIC_ID")
+	if introTopicIDStr != "" {
+		introTopicID, err := strconv.Atoi(introTopicIDStr)
 		if err != nil {
-			return nil, fmt.Errorf("invalid invite topic ID: %s", inviteTopicIDStr)
+			return nil, fmt.Errorf("invalid intro topic ID: %s", introTopicIDStr)
 		}
-		config.InviteTopicID = inviteTopicID
+		config.IntroTopicID = introTopicID
 	}
 
 	// Telegram User Client

--- a/internal/handlers/privatehandlers/intro_handler.go
+++ b/internal/handlers/privatehandlers/intro_handler.go
@@ -161,8 +161,8 @@ func (h *introHandler) processIntroSearch(b *gotgbot.Bot, ctx *ext.Context) erro
 	// Send typing action using MessageSender.
 	h.messageSenderService.SendTypingAction(msg.Chat.Id)
 
-	// Get messages from Invite topic
-	messages, err := clients.GetChatMessages(h.config.SuperGroupChatID, h.config.InviteTopicID)
+	// Get messages from Intro topic
+	messages, err := clients.GetChatMessages(h.config.SuperGroupChatID, h.config.IntroTopicID)
 	if err != nil {
 		h.messageSenderService.Reply(msg, "Произошла ошибка при получении сообщений из чата.", nil)
 		log.Printf("IntroHandler: Error during messages retrieval: %v", err)


### PR DESCRIPTION
This change updates the configuration and handler code to replace the "Invite" topic nomenclature with "Intro" topic. The environment variable has been changed from `TG_EVO_BOT_INVITE_TOPIC_ID` to `TG_EVO_BOT_INTRO_TOPIC_ID`, and corresponding log and error messages have also been updated. The change ensures consistency across the codebase for better clarity and alignment with the new naming convention.