### PR TITLE
✨ Add new inline keyboard markup with "Back", "Start", and "Cancel" b…

### DIFF
--- a/internal/buttons/profiles_manager_handler_buttons.go
+++ b/internal/buttons/profiles_manager_handler_buttons.go
@@ -23,6 +23,27 @@ func ProfilesBackCancelButtons(backCallbackData string) gotgbot.InlineKeyboardMa
 	}
 }
 
+func ProfilesBackStartCancelButtons(backCallbackData string) gotgbot.InlineKeyboardMarkup {
+	return gotgbot.InlineKeyboardMarkup{
+		InlineKeyboard: [][]gotgbot.InlineKeyboardButton{
+			{
+				{
+					Text:         "◀️ Назад",
+					CallbackData: backCallbackData,
+				},
+				{
+					Text:         "⏪ Старт",
+					CallbackData: constants.AdminProfilesStartCallback,
+				},
+				{
+					Text:         "❌ Отмена",
+					CallbackData: constants.AdminProfilesCancelCallback,
+				},
+			},
+		},
+	}
+}
+
 // ProfilesCoffeeBanButtons returns buttons for managing coffee ban status
 func ProfilesCoffeeBanButtons(backCallbackData string, hasCoffeeBan bool) gotgbot.InlineKeyboardMarkup {
 	var toggleButtonText string

--- a/internal/handlers/adminhandlers/profiles_manager_handler.go
+++ b/internal/handlers/adminhandlers/profiles_manager_handler.go
@@ -633,7 +633,7 @@ func (h *adminProfilesHandler) handlePublishProfile(b *gotgbot.Bot, ctx *ext.Con
 		fmt.Sprintf("<b>%s</b>", adminProfilesMenuPublishHeader)+
 			fmt.Sprintf("\n\n✅ Профиль пользователя успешно опубликован в канале \"<a href='%s'>Интро</a>\"!", utils.GetIntroMessageLink(h.config, profile.PublishedMessageID.Int64)),
 		&gotgbot.SendMessageOpts{
-			ReplyMarkup: buttons.ProfilesBackCancelButtons(constants.AdminProfilesEditMenuCallback),
+			ReplyMarkup: buttons.ProfilesBackStartCancelButtons(constants.AdminProfilesEditMenuCallback),
 		})
 
 	if err != nil {


### PR DESCRIPTION
…uttons in profiles manager

Introduce a new function `ProfilesBackStartCancelButtons` in `profiles_manager_handler_buttons.go` to create an inline keyboard with "Back", "Start", and "Cancel" options for managing admin profiles. Update the `handlePublishProfile` method in `profiles_manager_handler.go` to switch from `ProfilesBackCancelButtons` to the newly added `ProfilesBackStartCancelButtons`, allowing for the additional "Start" option in reply markup. This change enhances the navigational options available to administrators when managing user profiles in the bot interface.