### PR TITLE
⬇️ Decrease ProfileBioLengthLimit to 4096 to match maximum Telegram m…

### DIFF
--- a/internal/constants/general_constants.go
+++ b/internal/constants/general_constants.go
@@ -5,5 +5,5 @@ const CancelCommand = "cancel"
 
 // Profile fields
 const (
-	ProfileBioLengthLimit = 4500
+	ProfileBioLengthLimit = 4096 //max Telegram message length
 )


### PR DESCRIPTION
…essage length.