### PR TITLE
♿ Refactor profile button text for clarity

### DIFF
--- a/internal/buttons/profile_handler_buttons.go
+++ b/internal/buttons/profile_handler_buttons.go
@@ -21,11 +21,11 @@ func ProfileMainButtons() gotgbot.InlineKeyboardMarkup {
 			},
 			{
 				{
-					Text:         "📢 Опубликовать",
+					Text:         "📢 Опублик. (+ превью)",
 					CallbackData: constants.ProfilePublishCallback,
 				},
 				{
-					Text:         "📢 Опубликовать (без превью)",
+					Text:         "📢 Опублик. (- превью)",
 					CallbackData: constants.ProfilePublishWithoutPreviewCallback,
 				},
 			},


### PR DESCRIPTION
Updated the text labels for the profile publish buttons to make them more concise and clearer for users. The new labels are "📢 Опублик. (+ превью)" and "📢 Опублик. (- превью)", offering a straightforward choice between publishing with or without a preview. This change ensures better understanding and accessibility of the button functionalities while maintaining the original callback operations intact.