### PR TITLE
🚸 Reverse event order in GetLastEvents query to show the most recent …

### DIFF
--- a/internal/database/repositories/event_repository.go
+++ b/internal/database/repositories/event_repository.go
@@ -92,7 +92,7 @@ func (r *EventRepository) GetLastEvents(limit int) ([]Event, error) {
 	query := `
 		SELECT id, name, type, status, started_at, created_at, updated_at
 		FROM events
-		ORDER BY started_at ASC NULLS LAST
+		ORDER BY started_at DESC NULLS LAST
 		LIMIT $1`
 
 	rows, err := r.db.Query(query, limit)


### PR DESCRIPTION
…events first

Modified the SQL ORDER BY clause in the GetLastEvents function of the EventRepository to order events by started_at in descending order instead of ascending order. This change will display the most recently started events first, better aligning with the common expectations of 'last events' functionality. This adjustment enhances the usability and relevance of query results when retrieving a limited set of recent events.