### PR TITLE
feat(summarization): add daily topic message summarization from database

### DIFF
--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -104,7 +104,9 @@ func NewTgBotClient(openaiClient *clients.OpenAiClient, appConfig *config.Config
 		appConfig,
 		openaiClient,
 		messageSenderService,
+		groupTopicRepository,
 		promptingTemplateRepository,
+		groupMessageRepository,
 	)
 	randomCoffeeService := services.NewRandomCoffeeService(
 		bot,

--- a/internal/handlers/grouphandlers/replies_from_closed_threads_handler.go
+++ b/internal/handlers/grouphandlers/replies_from_closed_threads_handler.go
@@ -95,7 +95,6 @@ func (h *RepliesFromClosedThreadsHandler) forwardReplyMessage(ctx *ext.Context, 
 		msg.ReplyToMessage.MessageId)
 
 	// Get the topic name
-	// [todo] get topic name from database
 	groupTopic, err := h.groupTopicRepository.GetGroupTopicByTopicID(msg.MessageThreadId)
 	if err != nil {
 		log.Printf(


### PR DESCRIPTION
- Add GetByGroupTopicIDForLastDay method to group message repository
- Inject groupMessageRepository and groupTopicRepository into summarization service
- Retrieve and summarize messages from the last 24 hours for a topic
- Fetch topic name from database instead of using placeholder
- Update bot initialization to include new repositories for summarization use