### PR TITLE
fix(openai_client): update model and reasoning effort settings

### DIFF
--- a/internal/clients/openai_client.go
+++ b/internal/clients/openai_client.go
@@ -38,8 +38,8 @@ func (c *OpenAiClient) GetCompletion(ctx context.Context, message string) (strin
 		Messages: []openai.ChatCompletionMessageParamUnion{
 			openai.UserMessage(message),
 		},
-		Model:           openai.ChatModelGPT5,
-		ReasoningEffort: openai.ReasoningEffortMinimal,
+		Model:           openai.ChatModelGPT5Mini,
+		ReasoningEffort: openai.ReasoningEffortMedium,
 		//Model: openai.ChatModelO3Mini,
 		//Model: "o4-mini",
 		//Model: "gpt-4.1-mini",


### PR DESCRIPTION
- Change model from GPT-5 to GPT-5 Mini for completions
- Adjust reasoning effort from minimal to medium level
- Comment out unused alternative model configurations