### PR TITLE
docs(README): update help message and add TryLinkToLearn command

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A Telegram bot for Evocoders Club management implemented in Go. Helps moderate d
 - 📋 **Chat Summarization**: Creates daily summaries of conversations
   - Auto-posts at configured times
   - Manual trigger with `/trySummarize` (admin-only)
+  - Send a knowledge base link with `/tryLinkToLearn` (admin-only, private)
 
 ### 🎲 Weekly Random Coffee Meetings
 - **Automated Participation Poll**: Every week (configurable day and time in UTC, defaults to Friday at 2 PM UTC), the bot posts a poll asking members if they want to participate in random coffee meetings for the following week.
@@ -49,7 +50,7 @@ A Telegram bot for Evocoders Club management implemented in Go. Helps moderate d
 
 ### Administrative Controls
 - 👥 **Profiles Manager** (`/profilesManager`): Admin tool for managing user profiles
-- 🧪 **Test Handlers**: Manual testing tools for coffee pools (`/tryCreateCoffeePool`) and pair generation (`/tryGenerateCoffeePairs`)
+- 🧪 **Test Handlers**: Manual testing tools for coffee pools (`/tryCreateCoffeePool`), pair generation (`/tryGenerateCoffeePairs`), and sending knowledge base link (`/tryLinkToLearn`)
 - 📊 **Event Management**: Create, edit, start, and delete events (`/eventSetup`, `/eventEdit`, `/eventStart`, `/eventDelete`)
 
 ### Utility

--- a/internal/formatters/help_message_formatter.go
+++ b/internal/formatters/help_message_formatter.go
@@ -48,7 +48,8 @@ func FormatHelpMessage(isAdmin bool, config *config.Config) string {
 		testCommandsHelpText := "\n\n<b>⚙️ Команды для тестирования</b>\n" +
 			fmt.Sprintf("└ /%s - Ручная генерация саммаризации общения в клубе\n", constants.TrySummarizeCommand) +
 			fmt.Sprintf("└ /%s - Ручное создание нового опроса по Random Coffee\n", constants.TryCreateCoffeePoolCommand) +
-			fmt.Sprintf("└ /%s - Ручная генерация пар для Random Coffee\n", constants.TryGenerateCoffeePairsCommand)
+			fmt.Sprintf("└ /%s - Ручная генерация пар для Random Coffee\n", constants.TryGenerateCoffeePairsCommand) +
+			fmt.Sprintf("└ /%s - Отправить ссылку на базу знаний в ЛС\n", constants.TryLinkToLearnCommand)
 
 		helpText += adminHelpText
 		helpText += testCommandsHelpText

--- a/internal/handlers/adminhandlers/testhandlers/try_link_to_learn_handler.go
+++ b/internal/handlers/adminhandlers/testhandlers/try_link_to_learn_handler.go
@@ -39,7 +39,7 @@ func (h *tryLinkToLearnHandler) handle(b *gotgbot.Bot, ctx *ext.Context) error {
 
 	return h.messageService.Reply(
 		msg,
-		"База знаний Эволюции Кода",
+		"База знаний Эволюции Кода ➡️",
 		&gotgbot.SendMessageOpts{
 			ReplyMarkup: gotgbot.InlineKeyboardMarkup{
 				InlineKeyboard: [][]gotgbot.InlineKeyboardButton{{


### PR DESCRIPTION
- Added description for the new `/tryLinkToLearn` command in the README.
- Updated help message formatter to include the new command for sending a knowledge base link.
- Enhanced the response message for the knowledge base link to improve clarity.