### PR TITLE
refactor(handlers): change message reply to send method in TryLinkToL…

### DIFF
--- a/internal/handlers/adminhandlers/testhandlers/try_link_to_learn_handler.go
+++ b/internal/handlers/adminhandlers/testhandlers/try_link_to_learn_handler.go
@@ -37,8 +37,8 @@ func (h *tryLinkToLearnHandler) handle(b *gotgbot.Bot, ctx *ext.Context) error {
 		return nil
 	}
 
-	return h.messageService.Reply(
-		msg,
+	return h.messageService.Send(
+		msg.Chat.Id,
 		"База знаний Эволюции Кода ➡️",
 		&gotgbot.SendMessageOpts{
 			ReplyMarkup: gotgbot.InlineKeyboardMarkup{


### PR DESCRIPTION
…earnHandler

- Updated the message sending logic in TryLinkToLearnHandler to use the Send method instead of Reply, improving message handling for the knowledge base link response.